### PR TITLE
Handled exception when the WebSocket is not available

### DIFF
--- a/crmux.js
+++ b/crmux.js
@@ -149,7 +149,11 @@ wss.on('connection', function(ws) {
            var idMap = upstreamMap[wsUpstreamUrl].localIdToRemote[msgObj.id];
            delete upstreamMap[wsUpstreamUrl].localIdToRemote[msgObj.id];
            msgObj.id = idMap.id;
-           idMap.client.send(JSON.stringify(msgObj));
+           try {
+             idMap.client.send(JSON.stringify(msgObj));
+           } catch (err) {
+             console.log('e>' + err)
+           }
            if (program.debug) {
              console.log(String(idMap.client._id).blue + "> " + idMap.message.yellow);
              console.log(String(idMap.client._id).blue + "> " + JSON.stringify(msgObj).green);


### PR DESCRIPTION
This will handled the exception thrown when the websocket channel is closed. Instead of crashing the whole server it will continue normal operation.

This bug was causing issue with multiple browser connected when we were doing a page refresh. The new behaviour is that some of the browser will need to reconnect but at least the crmux process is still up. Before it was crashing the whole process.