### PR TITLE
Replay script/console events for late joining debugger clients

### DIFF
--- a/crmux.js
+++ b/crmux.js
@@ -163,8 +163,8 @@ wss.on('connection', function(ws) {
                // Unlike script parsed events, console messages
                // don't represent critical state needed for clients
                // to function properly, and therefore, to prevent
-               // unneccessary memory consumption, we maintain a smal
-               //  history window by pruning older log messages as needed.
+               // unneccessary memory consumption, we can maintain a small
+               // history window, by pruning older log messages as needed.
                if (consoleMessageEvents.length > CONSOLE_HISTORY_SIZE) {
                  consoleMessageEvents.shift();
                }

--- a/crmux.js
+++ b/crmux.js
@@ -143,7 +143,7 @@ wss.on('connection', function(ws) {
         localIdToRemote: {}
       };
       upstreamSocket.on('message', function(message) {
-        var msgObj = JSON.parse(message);
+         var msgObj = JSON.parse(message);
          if (!msgObj.id) { // this is an event, broadcast it
            upstreamMap[wsUpstreamUrl].clients.forEach(function(s) {
              if (program.debug)


### PR DESCRIPTION
While using `crmux` in order to debug a Node.js app via two instances of Visual Studio Code, I noticed that the second VS Code instance wasn't able to properly step debug (it couldn't map the file location of the `Debugger.paused` event with the local file), and that the `Debug Console` window wasn't being properly populated open attaching the debugger. 

This PR resolves both issues by capturing the `Debugger.scriptParsed`, `Console.messageAdded` and `Runtime.consoleAPICalled` events coming from the debuggee process (e.g. Node.js in this case), and then "replaying" them as soon as any new debugger clients connect to `crmux`. This way, all new clients will immediately know the critical state of the world, and can begin moving forward in sync with other clients.